### PR TITLE
fix: make single repo query not use graphQL

### DIFF
--- a/gh-my
+++ b/gh-my
@@ -169,13 +169,35 @@ function query_deployments() {
     case "${flag}" in
     o) org="org:${OPTARG}" ;;
     t) topic="topic:${OPTARG}" ;;
-    r) repo="repo:${OPTARG}" ;;
+    r) repo="${OPTARG}" ;;
     *) query_help ;;
     esac
   done
   if [[ "$org" == "" && $topic = "" && $repo = "" ]]; then
     query_help
   fi
+  if [[ $repo != "" ]]; then
+    internal::repo_deploys "$repo"
+  else
+    queryString="$org $topic"
+    internal::org_deploys "$queryString"
+  fi
+}
+
+# Query a specific repo for any deployments that are in a "waiting" state
+function internal::repo_deploys() {
+  repo="$1"
+  # shellcheck disable=SC2016
+  deploy_template='{{tablerow "ID" "URL" "Branch" "When" -}}
+{{ range . -}}
+{{tablerow (.databaseId | autocolor "green") (.url | autocolor "cyan") (.headBranch | autocolor "yellow") (timeago .startedAt) -}}
+{{end -}}'
+  gh run list --repo "$repo" --json "databaseId,url,headBranch,startedAt" --template "$deploy_template" -s "waiting"
+}
+
+# Query the org, (filtering by topic) listing deploymens in a waiting state that on the default branch
+function internal::org_deploys() {
+  queryString="$1"
   # shellcheck disable=SC2016
   deploy_template='{{tablerow "Repo" "ID" "Env" "Actionable" "URL" "When" -}}
 {{range(pluck "node" .data.search.edges) -}}{{ $repo:=.nameWithOwner -}}
@@ -183,7 +205,6 @@ function query_deployments() {
 {{tablerow $repo (.databaseId | autocolor "green") .pendingDeploymentRequest.environment.name .pendingDeploymentRequest.currentUserCanApprove (.url | autocolor "cyan") (timeago .startedAt) -}}{{end -}}
 {{tablerender}}{{end -}}{{end -}}
 '
-  queryString="$repo $org $topic"
   # shellcheck disable=SC2016
   query='query($queryString: String!, $endCursor: String) {
       search(query: $queryString type: REPOSITORY, first: 100, after: $endCursor ) {
@@ -225,6 +246,7 @@ function query_deployments() {
     }'
   gh api graphql --paginate -F queryString="$queryString" --raw-field query="$query" --template "$deploy_template"
 }
+
 
 ACTION=$1 || true
 ACTION=${ACTION:="help"}


### PR DESCRIPTION
Fixes https://github.com/quotidian-ennui/gh-my/issues/5 or at least ensures that we get a proper report if someone is in fact just querying a repo.

- Entrypoint is still via 'deployments' but we branch behaviour on repo != null to a different function that just uses gh run list to do the required.
- Because of the magic of bash we can pretty much call our internal functions whatever we like so how about `::` as a rusty style separator ;)
- Output is different because we can't get the same information out of the REST API.

## Testing

Checkout the branch and run ./gh-my manually

```
bsh ❯ ./gh-my deployments -o telus-agcg -t tpm-demeter
Repo                                   ID           Env            Actionable  URL                                                                        When
telus-agcg/tpm-demeter-terraform-test  14505914355  main-approval  false       https://github.com/telus-agcg/tpm-demeter-terraform-test/runs/14505914355  3 days ago

bsh ❯ ./gh-my deployments -r telus-agcg/retro-cdc
ID          URL                                                              Branch  When
5388868900  https://github.com/telus-agcg/retro-cdc/actions/runs/5388868900  main    32 minutes ago
```