### PR TITLE
fix: use workflowRun URL

### DIFF
--- a/gh-my
+++ b/gh-my
@@ -67,7 +67,7 @@ function query_workload() {
             }
           }
         }'
-  gh api graphql --paginate --raw-field query="$query" --template "$TEMPLATE"
+  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
 }
 
 function query_reviews() {
@@ -98,7 +98,7 @@ function query_reviews() {
             }
           }
         }'
-  gh api graphql --paginate --raw-field query="$query" --template "$TEMPLATE"
+  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
 }
 
 function query_issues() {
@@ -128,7 +128,7 @@ function query_issues() {
             }
           }
         }'
-  gh api graphql --paginate --raw-field query="$query" --template "$TEMPLATE"
+  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
 }
 
 function query_prs() {
@@ -158,7 +158,7 @@ function query_prs() {
             }
           }
         }'
-  gh api graphql --paginate --raw-field query="$query" --template "$TEMPLATE"
+  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
 }
 
 function query_deployments() {
@@ -259,7 +259,14 @@ function internal::org_deploys() {
     }
   }
 }'
-  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$query" --template "$deploy_template"
+  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template "$deploy_template"
+}
+
+
+# This is clearly a bout of premature optimisation and saving
+# a few newlines & spaces shouldn't be high on anyone's list
+function internal::compressQuery() {
+  echo "$1" | tr -d '\n'
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/quotidian-ennui/gh-my/issues/7

- Change GraphQL query to use workflowRun.databaseId etc so that links point to the right place.
- refactor: make columns similar in order to -r filter so that ID/URL/Branch are now the first 3 items (so if you wanted to script something you can at least use `cut -f 2`...) 

## Testing

- Checkout the branch and run ./gh-my directly

```
bsh ❯ ./gh-my deployments -o telus-agcg -t tpm-demeter
ID          URL                                                                               Branch  Repo                                   Env            Actionable  When
5357752484  https://github.com/telus-agcg/tpm-demeter-terraform-test/actions/runs/5357752484  main    telus-agcg/tpm-demeter-terraform-test  main-approval  false       3 days ago
```

Should have more repos tagged with `tpm-demeter` with waiting jobs to see if it's still correct.