### PR TITLE
feat: add report function

### DIFF
--- a/gh-my
+++ b/gh-my
@@ -11,12 +11,14 @@ function query_help()
 {
   cat << EOF
 
-Usage: gh my [issues|prs|reviews|workload|deployments] [options]
-  issues:      list issues in your personal repositories
-  prs:         list PRs in your persional repositories
-  reviews:     list PRs where you've been asked for a review
-  workload:    list PRs and issues where you are the assignee
-  deployments: list deployments awaiting action on the default branch
+Usage: gh my [issues|prs|reviews|workload|report|deployments] [options]
+  issues      : list issues in your personal repositories
+  prs         : list PRs in your persional repositories
+  reviews     : list PRs where you've been asked for a review
+  workload    : list PRs and issues where you are the assignee
+  deployments : list deployments awaiting action on the default branch
+  report      : show all the issues & prs you've worked on in the last 14 days
+                (because you have to tell people what you've done)
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -182,6 +184,60 @@ function query_deployments() {
     queryString="$org $topic"
     internal::org_deploys "$queryString"
   fi
+}
+
+# Get all the issues & PRs authored by me in the last 14 days.
+# Potentially shouldn't have issues, since issues created by me might be worked on by me
+# Issues assigned to me will eventually have a PR created by me.
+# PR's assigned to me are a category mystery, why assigned as opposed to review.
+function query_report() {
+  report_template='
+{{tablerow "Num" "Title" "Repository" "URL" "Last Activity" -}}
+{{range(pluck "node" .data.search.edges) -}}
+{{tablerow (printf "#%v" .number | autocolor "green") .title (.repository.nameWithOwner | autocolor "yellow") (.url | autocolor "cyan") (timeago .updatedAt)  -}}
+{{end -}}
+{{tablerender}}
+'
+  queryString="author:@me updated:>=$(date --date="14 days ago" '+%Y-%m-%d') archived:false"
+  # shellcheck disable=SC2016
+  query='query ($queryString: String!, $endCursor: String){
+          search(query: $queryString,after: $endCursor, type: ISSUE, first: 50) {
+            edges {
+              node {
+                ... on PullRequest {
+                  number
+                  title
+                  author {
+                    login
+                  }
+                  reviewDecision
+                  updatedAt
+                  url
+                  repository {
+                    nameWithOwner
+                  }
+                }
+                ... on Issue {
+                  number
+                  title
+                  author {
+                    login
+                  }
+                  updatedAt
+                  url
+                  repository {
+                    nameWithOwner
+                  }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }'
+  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template "$report_template"
 }
 
 # Query a specific repo for any deployments that are in a "waiting" state


### PR DESCRIPTION

```
bsh ❯ gh-my report

Num   Title                                                              Repository                              URL                                                                Last Activity
#8    fix: use workflowRun URL                                           quotidian-ennui/gh-my                   https://github.com/quotidian-ennui/gh-my/pull/8                    36 minutes ago
#7    deployments URL is not the action run URL                          quotidian-ennui/gh-my                   https://github.com/quotidian-ennui/gh-my/issues/7                  36 minutes ago
#6    fix: make single repo query not use graphQL                        quotidian-ennui/gh-my                   https://github.com/quotidian-ennui/gh-my/pull/6                    2 hours ago
#5    deployments -r filter isn't always reliable                        quotidian-ennui/gh-my                   https://github.com/quotidian-ennui/gh-my/issues/5                  2 hours ago
#256  refactor(ci): merge clippy & audit workflows into a single action  telus-agcg/retro-cdc                    https://github.com/telus-agcg/retro-cdc/pull/256                   19 hours ago
```

Should work in powershell since date is a built in exe for git+bash, but needs testing post merge