### PR TITLE
feat: add notifications sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gh extension install quotidian-ennui/gh-my
 ## Usage
 
 ```
-Usage: gh my [issues|prs|reviews|workload|report|deployments] [options]
+Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs] [options]
   issues      : list issues in your personal repositories
   prs         : list PRs in your persional repositories
   reviews     : list PRs where you've been asked for a review
@@ -26,6 +26,7 @@ Usage: gh my [issues|prs|reviews|workload|report|deployments] [options]
   deployments : list deployments awaiting action on the default branch
   report      : show all the issues & prs you've worked on in the last 14 days
                 (because you have to tell people what you've done)
+  notifs      : list unread notifications
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -36,6 +37,9 @@ Report generation uses 'date' so any gnu date string is valid
   -d : the date string (default is "14 days ago")
   -q : omit the table headers
 
+Listing notifications can also mark them as read
+  -n : the ID to mark as read (-n 7235590448)
+  -a : Mark all notifications as read
 ```
 
 ```

--- a/gh-my
+++ b/gh-my
@@ -11,7 +11,7 @@ function query_help()
 {
   cat << EOF
 
-Usage: gh my [issues|prs|reviews|workload|report|deployments] [options]
+Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs] [options]
   issues      : list issues in your personal repositories
   prs         : list PRs in your persional repositories
   reviews     : list PRs where you've been asked for a review
@@ -19,6 +19,7 @@ Usage: gh my [issues|prs|reviews|workload|report|deployments] [options]
   deployments : list deployments awaiting action on the default branch
   report      : show all the issues & prs you've worked on in the last 14 days
                 (because you have to tell people what you've done)
+  notifs      : list unread notifications
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -28,6 +29,10 @@ Listing deployments needs more filters
 Report generation uses 'date' so any gnu date string is valid
   -d : the date string (default is "14 days ago")
   -q : omit the table headers
+
+Listing notifications can also mark them as read
+  -n : the ID to mark as read (-n 7235590448)
+  -a : Mark all notifications as read
 
 EOF
  exit 1
@@ -259,6 +264,36 @@ function query_report() {
         }'
   gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template "$report_template"
 }
+
+function query_notifs() {
+  notif_template='{{tablerow "ID" "Reason" "When" "Repo" "Title" -}}
+{{ range . -}}
+{{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (hyperlink "https://github.com/notifications" (.subject.title | autocolor "yellow")) -}}
+{{end -}}'
+
+  notif_id=''
+  mark_all_as_read=''
+  while getopts 'n:a' flag; do
+    case "${flag}" in
+    n) notif_id="${OPTARG}" ;;
+    a) mark_all_as_read="yes" ;;
+    *) query_help ;;
+    esac
+  done
+
+  if [[ -z "$notif_id" && -z "$mark_all_as_read" ]]; then
+    # Show notifications
+    gh api notifications --template "$notif_template"
+  fi
+  if [[ -n "$notif_id" ]]; then
+    gh api "notifications/threads/$notif_id" --method PATCH --silent
+  fi
+  if [[ -n "$mark_all_as_read" ]]; then
+    gh api "notifications" --method PUT --silent
+  fi
+
+}
+
 
 # Query a specific repo for any deployments that are in a "waiting" state
 function internal::repo_deploys() {


### PR DESCRIPTION
Adds a simple interface to show you all your unread notifications.

>Note that the Title currently is just a link to `https://github.com/notifications` since the JSON response doesn't contain a true link to (in this case http://github.com/telus-agcg/adx-core-github-push-mirror/pull/50) (or whatever the PR is).

```
bsh ❯ ./gh-my notifs
ID          Reason            When            Repo                                    Title
7235590448  review_requested  46 minutes ago  telus-agcg/adx-core-github-push-mirror  deps(tf): bump integrations/github from 5.31.0 to 5.32.0 in /terraform
7238540107  review_requested  1 hour ago      telus-agcg/adx-core-infra-bootstrap     build(deps): bump hashicorp/google from 4.75.1 to 4.76.0

# Now mark a single notification as read.
bsh ❯ ./gh-my notifs -n 7235590448
bsh ❯ ./gh-my notifs
ID          Reason            When        Repo                                 Title
7238540107  review_requested  1 hour ago  telus-agcg/adx-core-infra-bootstrap  build(deps): bump hashicorp/google from 4.75.1 to 4.76.0

# Now mark all the notifications as read.
bsh ❯ ./gh-my notifs -a
bsh ❯ ./gh-my notifs
ID  Reason  When  Repo  Title
```

Could switch to using graphql to get a URL from the graph, but this way was painless
