### PR TITLE
feat: add failures sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This is an extension for [GitHub CLI](https://cli.github.com/) that just lists a
 ## Installation
 
 Prerequisites:
- * [GitHub CLI](https://cli.github.com/) is already installed and authenticated
+ - [GitHub CLI](https://cli.github.com/) is already installed and authenticated
+ - [`jq`](https://stedolan.github.io/jq/) is installed
+ - `column` which is a standard linux tool; already present in _git+bash_ on windows; via _util-linux_ on ubuntu.
+ - `date` needs to support the `--date "14 days ago"` style option.
 
 To install this extension:
 
@@ -18,7 +21,7 @@ gh extension install quotidian-ennui/gh-my
 ## Usage
 
 ```
-Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs] [options]
+Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs|failures] [options]
   issues      : list issues in your personal repositories
   prs         : list PRs in your persional repositories
   reviews     : list PRs where you've been asked for a review
@@ -27,6 +30,7 @@ Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs] [options]
   report      : show all the issues & prs you've been involved in the last 14 days
                 (because you have to tell people what you've done)
   notifs      : list unread notifications
+  failures    : show workflow failures in your personal repositories in the last 14 days
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -38,6 +42,9 @@ Report generation uses 'date' so any gnu date string is valid
   -q : omit the table headers
   -a : use 'author' instead of 'involves'
   -v : everything involving your user (e.g. where you're a CODEOWNER)
+
+Failure generation uses 'date' so any gnu date string is valid
+  -d : the date string (default is "14 days ago")
 
 Listing notifications can also mark them as read
   -n : the ID to mark as read (-n 7235590448)

--- a/gh-my
+++ b/gh-my
@@ -6,12 +6,19 @@ TEMPLATE='{{tablerow "Num" "Title" "Who" "URL" "When" -}}
 {{tablerow (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
 {{end -}}
 {{tablerender}}'
+GH_REST_API_VERSION="X-GitHub-Api-Version: 2022-11-28"
+GH_ACCEPT="Accept: application/vnd.github+json"
+export GH_PAGER="cat"
+
+function gh_api() {
+  gh api -H "$GH_REST_API_VERSION" -H "$GH_ACCEPT" "$@"
+}
 
 function query_help()
 {
   cat << EOF
 
-Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs] [options]
+Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs|failures] [options]
   issues      : list issues in your personal repositories
   prs         : list PRs in your persional repositories
   reviews     : list PRs where you've been asked for a review
@@ -20,6 +27,7 @@ Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs] [options]
   report      : show all the issues & prs you've been involved in the last 14 days
                 (because you have to tell people what you've done)
   notifs      : list unread notifications
+  failures    : show workflow failures in your repos
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -31,6 +39,9 @@ Report generation uses 'date' so any gnu date string is valid
   -q : omit the table headers
   -a : use 'author' instead of 'involves'
   -v : everything involving your user (e.g. where you're a CODEOWNER)
+
+Failure generation uses 'date' so any gnu date string is valid
+  -d : the date string (default is "14 days ago")
 
 Listing notifications can also mark them as read
   -n : the ID to mark as read (-n 7235590448)
@@ -375,6 +386,29 @@ function internal::org_deploys() {
   gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template "$deploy_template"
 }
 
+# Query your repos for workflow failures
+query_failures() {
+  local since='14 days ago'
+  while getopts 'd:' flag; do
+    case "${flag}" in
+    d) since="${OPTARG}" ;;
+    esac
+  done
+  local since_epoch=$(date -d "$since" "+%s")
+  local jq_filter=$(cat <<-EOF
+  .workflow_runs[] |  select ((.created_at | fromdateiso8601) > $since_epoch) |
+  "\(.repository.name)|\(.name)|\(.html_url)|\(.created_at | fromdateiso8601 | strflocaltime("%d %b %Y"))"
+EOF
+  )
+  local gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
+  {
+    for gh_repo in $gh_repos; do
+      failed_workflows=$(gh_api "repos/$gh_repo/actions/runs?status=failure")
+      echo "$failed_workflows" | jq -r "$jq_filter"
+    done
+  } | column -s'|' -t -N "REPOSITORY,WORKFLOW,URL,WHEN"
+
+}
 
 # This is clearly a bout of premature optimisation and saving
 # a few newlines & spaces shouldn't be high on anyone's list

--- a/gh-my
+++ b/gh-my
@@ -388,7 +388,7 @@ function internal::org_deploys() {
 # Query your repos for workflow failures
 query_failures() {
   local since
-  local since_epoch
+  local since_dateonly
   local jq_filter
   local gh_repos
   since='14 days ago'
@@ -398,16 +398,12 @@ query_failures() {
     *) ;;
     esac
   done
-  since_epoch=$(date --date="$since" "+%s")
-  jq_filter=$(cat <<-EOF
-  .workflow_runs[] |  select ((.created_at | fromdateiso8601) > $since_epoch) |
-  "\(.repository.name)|\(.name)|\(.html_url)|\(.created_at | fromdateiso8601 | strflocaltime("%d %b %Y"))"
-EOF
-  )
+  since_dateonly=$(date --date="$since" '+%Y-%m-%d')
+  jq_filter='.workflow_runs[] | "\(.repository.name)|\(.name)|\(.html_url)|\(.created_at | fromdateiso8601 | strflocaltime("%d %b %Y"))"'
   gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
   {
     for gh_repo in $gh_repos; do
-      failed_workflows=$(gh_api "repos/$gh_repo/actions/runs?status=failure")
+      failed_workflows=$(gh_api "repos/$gh_repo/actions/runs?status=failure&created=>$since_dateonly")
       echo "$failed_workflows" | jq -r "$jq_filter"
     done
   } | column -s'|' -t -N "REPOSITORY,WORKFLOW,URL,WHEN"

--- a/gh-my
+++ b/gh-my
@@ -8,7 +8,6 @@ TEMPLATE='{{tablerow "Num" "Title" "Who" "URL" "When" -}}
 {{tablerender}}'
 GH_REST_API_VERSION="X-GitHub-Api-Version: 2022-11-28"
 GH_ACCEPT="Accept: application/vnd.github+json"
-export GH_PAGER="cat"
 
 function gh_api() {
   gh api -H "$GH_REST_API_VERSION" -H "$GH_ACCEPT" "$@"
@@ -27,7 +26,7 @@ Usage: gh my [issues|prs|reviews|workload|report|deployments|notifs|failures] [o
   report      : show all the issues & prs you've been involved in the last 14 days
                 (because you have to tell people what you've done)
   notifs      : list unread notifications
-  failures    : show workflow failures in your repos
+  failures    : show workflow failures in your personal repositories in the last 14 days
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -388,26 +387,30 @@ function internal::org_deploys() {
 
 # Query your repos for workflow failures
 query_failures() {
-  local since='14 days ago'
+  local since
+  local since_epoch
+  local jq_filter
+  local gh_repos
+  since='14 days ago'
   while getopts 'd:' flag; do
     case "${flag}" in
     d) since="${OPTARG}" ;;
+    *) ;;
     esac
   done
-  local since_epoch=$(date -d "$since" "+%s")
-  local jq_filter=$(cat <<-EOF
+  since_epoch=$(date --date="$since" "+%s")
+  jq_filter=$(cat <<-EOF
   .workflow_runs[] |  select ((.created_at | fromdateiso8601) > $since_epoch) |
   "\(.repository.name)|\(.name)|\(.html_url)|\(.created_at | fromdateiso8601 | strflocaltime("%d %b %Y"))"
 EOF
   )
-  local gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
+  gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
   {
     for gh_repo in $gh_repos; do
       failed_workflows=$(gh_api "repos/$gh_repo/actions/runs?status=failure")
       echo "$failed_workflows" | jq -r "$jq_filter"
     done
   } | column -s'|' -t -N "REPOSITORY,WORKFLOW,URL,WHEN"
-
 }
 
 # This is clearly a bout of premature optimisation and saving


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Just needed to be able to track workflow failures in my personal repositories in a single command.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add failures as a sub command
<!-- SQUASH_MERGE_END -->

## Notes

Not that happy that I haven't figured out the approprate GraphQL query to do this, since using the rest API when you have lots of personal repositories is going to hit your API limits (-1 per repo).

- Could conceivably do the same as query_deployments to find all failed workflows in an organisation by topic; need an organisation with topics first...
- At what point do you say, lets not use bash, lets write a golang util?

## Testing

Need some recent failed workflows, but you should be able to do something like this

```
bsh ❯ ./gh-my failures
REPOSITORY             WORKFLOW          URL                                                                               WHEN
ubuntu-dpm             dependabot-merge  https://github.com/quotidian-ennui/ubuntu-dpm/actions/runs/7666769099             26 Jan 2024
ubuntu-dpm             dependabot-merge  https://github.com/quotidian-ennui/ubuntu-dpm/actions/runs/7666767087             26 Jan 2024
interlok-build-parent  Build PR (95)     https://github.com/quotidian-ennui/interlok-build-parent/actions/runs/7571840196  18 Jan 2024
parquet-cli-wrapper    Merge PR (6)      https://github.com/quotidian-ennui/parquet-cli-wrapper/actions/runs/7699272495    29 Jan 2024
parquet-cli-wrapper    Merge PR (5)      https://github.com/quotidian-ennui/parquet-cli-wrapper/actions/runs/7699271435    29 Jan 2024
actions-olio           PR Build Trigger  https://github.com/quotidian-ennui/actions-olio/actions/runs/7699870329           29 Jan 2024
```

