### PR TITLE
feat: add vulnerability alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gh extension install quotidian-ennui/gh-my
 ## Usage
 
 ```
-Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|workload] [options]
+Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|workload] [options]
   issues      : list issues in your personal repositories
   prs         : list PRs in your persional repositories
   reviews     : list PRs where you've been asked for a review
@@ -31,6 +31,7 @@ Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|workloa
                 (because you have to tell people what you've done)
   notifs      : list unread notifications
   failures    : show workflow failures in your personal repositories in the last 14 days
+  vulns       : show vulnerability alerts from dependabot in your personal repositories
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -49,6 +50,11 @@ Failure generation uses 'date' so any gnu date string is valid
 Listing notifications can also mark them as read
   -n : the ID to mark as read (-n 7235590448)
   -a : Mark all notifications as read
+
+Listing vulnerabilities can have more filters
+  -o : the owner (e.g. -o my-company | -o my-user)
+       default is whatever 'gh config get user -h github.com' returns
+       ** Viewing security alerts implies permissions
 ```
 
 ```

--- a/includes/query_help
+++ b/includes/query_help
@@ -14,6 +14,7 @@ Usage: gh my [$ACTION_LIST] [options]
                 (because you have to tell people what you've done)
   notifs      : list unread notifications
   failures    : show workflow failures in your personal repositories in the last 14 days
+  vulns       : show vulnerability alerts from dependabot in your personal repositories
 
 Listing deployments needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -33,6 +34,10 @@ Listing notifications can also mark them as read
   -n : the ID to mark as read (-n 7235590448)
   -a : Mark all notifications as read
 
+Listing vulnerabilities can have more filters
+  -o : the owner (e.g. -o my-company | -o my-user)
+       default is whatever 'gh config get user -h github.com' returns
+       ** Viewing security alerts implies permissions
 EOF
  exit 1
 }

--- a/includes/query_vulns
+++ b/includes/query_vulns
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+function query_vulns() {
+
+  local whoami
+  whoami=$(gh config get user -h github.com)
+  while getopts 'o:' flag; do
+    case "${flag}" in
+    o) whoami="${OPTARG}" ;;
+    *) query_help ;;
+    esac
+  done
+
+  local queryString="owner:$whoami archived:false"
+  # shellcheck disable=SC2016
+  local template='{{tablerow "Repository" "Package" "URL" "Created" -}}
+{{range(pluck "node" .data.search.edges) -}}
+{{ $repo:=.nameWithOwner -}}
+{{range .vulnerabilityAlerts.nodes -}}
+{{ $url:= printf "https://github.com/%s/security/dependabot/%v" $repo .number -}}
+{{tablerow ($repo | autocolor "green")
+          (.securityVulnerability.package.name | autocolor "cyan")
+          ($url | autocolor "yellow")
+          (timeago .createdAt) -}}
+{{end -}}
+{{end -}}
+'
+  # shellcheck disable=SC2016
+  local query='query($searchQuery: String!, $endCursor: String) {
+  search(query: $searchQuery, type: REPOSITORY, first: 100, after: $endCursor) {
+    edges {
+      node {
+        ... on Repository {
+          nameWithOwner
+          vulnerabilityAlerts(first: 100, states:OPEN) {
+            nodes {
+              createdAt
+              vulnerableManifestPath
+              vulnerableManifestFilename
+              number
+              securityVulnerability {
+                package {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}'
+  gh api graphql --paginate -F searchQuery="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template="$template"
+}
+
+


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Because dependabot sometimes gets a bit confused about vulnerabilities and raises alerts where it shouldn't. You might not remember to go into the UI for each repository and look at the alerts (which aren't necessarily all that obvious).

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- use graphQL to interrogate the vulnerabilityAlerts object
- allow override of the owner with -o for vulns
<!-- SQUASH_MERGE_END -->

## Notes

- code scanning alerts & secret scanning alerts don't appear to be available in GraphQL (as of 2024-02-23), there are equivalents on a per repository / org basis with the REST api that iterating over all your personal repositories like failed workflows doesn't fill me with joy.
- Toyed with adding a `-s "OPEN|FIXED"` parameter, which might be reasonable but do you realistically care about anything other than open ones.

## Testing

> Might need some actual vulnerability alerts (or at least FIXED ones).

```
bsh ❯ gh extension remove gh-my
bsh ❯ gh extension install .
bsh ❯ gh my vulns
Repository                    Package                   URL                                                                    Created
quotidian-ennui/actions-olio  tj-actions/changed-files  https://github.com/quotidian-ennui/actions-olio/security/dependabot/1  4 days ago
```

If you don't have any "open security alerts" but you do have some fixed ones, then you can edit `query_vulns` and change the OPEN to FIXED in the graphql query.
