### PR TITLE
feat: add json output to issues/workload/prs/reviews

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,26 @@
+set positional-arguments := true
+alias format:=fmt
+
+# show recipes
+[private]
+@help:
+  just --list --list-prefix "  "
+
+# Run shellcheck + shfmt
+lint: fmt shellcheck
+
+# Run shellcheck
+@shellcheck:
+  shellcheck gh-my
+  shellcheck includes/query_*
+  shellcheck includes/helper_*
+
+# Run shfmt
+fmt:
+  #!/usr/bin/env bash
+  set -eo pipefail
+
+  shfmt -i 2 -w gh-my
+  for file in "{{ justfile_directory() }}"/includes/*; do
+    shfmt -i 2 -w "$file"
+  done

--- a/gh-my
+++ b/gh-my
@@ -1,23 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-#shellcheck disable=SC2034
-TEMPLATE='{{tablerow "Num" "Title" "Who" "URL" "When" -}}
-{{range(pluck "node" .data.search.edges) -}}
-{{tablerow (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
-{{end -}}
-{{tablerender}}'
-GH_REST_API_VERSION="X-GitHub-Api-Version: 2022-11-28"
-GH_ACCEPT="Accept: application/vnd.github+json"
 BASEDIR=$(dirname "$0")
-
 ACTION_LIST=""
 
-function gh_api() {
-  gh api -H "$GH_REST_API_VERSION" -H "$GH_ACCEPT" "$@"
-}
-
-function source_actions() {
+source_actions() {
   for f in "$BASEDIR"/includes/query_*; do
     #shellcheck disable=SC1090
     source "$f"
@@ -27,10 +14,8 @@ function source_actions() {
   ACTION_LIST=${ACTION_LIST%?}
 }
 
-function internal::compressQuery() {
-  echo "$1" | tr -s ' ' | tr -d '\n'
-}
-
+#shellcheck disable=SC1091
+source "$BASEDIR/includes/helper_functions"
 source_actions
 ACTION=$1 || true
 ACTION=${ACTION:="help"}
@@ -41,5 +26,13 @@ if [[ ! "${ACTION}" =~ ^$ACTION_LIST$ ]]; then
   query_help
 fi
 
-"query_${ACTION}" "$@"
+# Turn 'global' longopts into short
+for arg in "$@"; do
+  shift
+  case "$arg" in
+  --jsonlines | --json) set -- "$@" '-j' ;;
+  *) set -- "$@" "$arg" ;;
+  esac
+done
 
+"query_${ACTION}" "$@"

--- a/includes/helper_functions
+++ b/includes/helper_functions
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+GH_REST_API_VERSION="X-GitHub-Api-Version: 2022-11-28"
+GH_ACCEPT="Accept: application/vnd.github+json"
+
+#shellcheck disable=SC2034
+STD_TABLE_TEMPLATE='{{tablerow "Num" "Title" "Who" "URL" "When" -}}
+{{range(pluck "node" .data.search.edges) -}}
+{{tablerow (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+{{end -}}
+{{tablerender}}'
+
+STD_JQ_FILTER='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "url": .url, "createdAt": .createdAt}'
+STD_OUTPUT_FORMAT="table"
+
+helper::gh_api() {
+  gh api -H "$GH_REST_API_VERSION" -H "$GH_ACCEPT" "$@"
+}
+
+helper::compressQuery() {
+  echo "$1" | tr -s ' ' | tr -d '\n'
+}
+
+helper::std_output_format() {
+  local query="$1"
+  while getopts 'j' flag; do
+    case "${flag}" in
+    j) STD_OUTPUT_FORMAT="json" ;;
+    *) query_help ;;
+    esac
+  done
+}
+
+helper::std_graphql() {
+  local query="$1"
+  case $STD_OUTPUT_FORMAT in
+  json)
+    gh api graphql --paginate --raw-field query="$(helper::compressQuery "$query")" --jq "$STD_JQ_FILTER" | jq -c "."
+    ;;
+  *)
+    gh api graphql --paginate --raw-field query="$(helper::compressQuery "$query")" --template="$STD_TABLE_TEMPLATE"
+    ;;
+  esac
+}

--- a/includes/query_deployments
+++ b/includes/query_deployments
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-function query_deployments() {
-  org=''
-  topic=''
-  repo=''
+query_deployments() {
+  local org=''
+  local topic=''
+  local repo=''
   while getopts 'o:t:r:' flag; do
     case "${flag}" in
     o) org="org:${OPTARG}" ;;
@@ -24,10 +24,10 @@ function query_deployments() {
 }
 
 # Query a specific repo for any deployments that are in a "waiting" state
-function internal::repo_deploys() {
-  repo="$1"
+internal::repo_deploys() {
+  local repo="$1"
   # shellcheck disable=SC2016
-  deploy_template='{{tablerow "ID" "URL" "Branch" "When" -}}
+  local deploy_template='{{tablerow "ID" "URL" "Branch" "When" -}}
 {{ range . -}}
 {{tablerow (.databaseId | autocolor "green") (.url | autocolor "cyan") (.headBranch | autocolor "yellow") (timeago .startedAt) -}}
 {{end -}}'
@@ -35,10 +35,10 @@ function internal::repo_deploys() {
 }
 
 # Query the org, (filtering by topic) listing deploymens in a waiting state that on the default branch
-function internal::org_deploys() {
-  queryString="$1"
+internal::org_deploys() {
+  local queryString="$1"
   # shellcheck disable=SC2016
-  deploy_template='{{tablerow "ID" "URL" "Branch" "Repo" "Env" "Actionable" "When" -}}
+  local deploy_template='{{tablerow "ID" "URL" "Branch" "Repo" "Env" "Actionable" "When" -}}
 {{range(pluck "node" .data.search.edges) -}}
 {{ $repo:=.nameWithOwner -}}{{ $branch:=.defaultBranchRef.name -}}
 {{range(pluck "workflowRun" .defaultBranchRef.target.checkSuites.nodes) -}}{{ $workflowId:= .databaseId -}}{{ $workflowRunURL:= .url -}}
@@ -55,7 +55,8 @@ function internal::org_deploys() {
 {{end -}}
 '
   # shellcheck disable=SC2016
-  query='query ($queryString: String!, $endCursor: String) {
+  query='
+query ($queryString: String!, $endCursor: String) {
   search(query: $queryString, type: REPOSITORY, first: 100, after: $endCursor) {
     edges {
       node {
@@ -98,5 +99,5 @@ function internal::org_deploys() {
     }
   }
 }'
-  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template "$deploy_template"
+  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$query")" --template "$deploy_template"
 }

--- a/includes/query_failures
+++ b/includes/query_failures
@@ -17,7 +17,7 @@ query_failures() {
   gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
   {
     for gh_repo in $gh_repos; do
-      failed_workflows=$(gh_api "repos/$gh_repo/actions/runs?status=failure&created=>$since_dateonly")
+      failed_workflows=$(helper::gh_api "repos/$gh_repo/actions/runs?status=failure&created=>$since_dateonly")
       echo "$failed_workflows" | jq -r "$jq_filter"
     done
   } | column -s'|' -t -N "REPOSITORY,WORKFLOW,URL,WHEN"

--- a/includes/query_help
+++ b/includes/query_help
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-function query_help()
-{
-  cat << EOF
+query_help() {
+  cat <<EOF
 
 Usage: gh my [$ACTION_LIST] [options]
   issues      : list issues in your personal repositories
@@ -16,7 +15,10 @@ Usage: gh my [$ACTION_LIST] [options]
   failures    : show workflow failures in your personal repositories in the last 14 days
   vulns       : show vulnerability alerts from dependabot in your personal repositories
 
+'issues' can have its output in JSON format
+'prs' can have its output in JSON format
 'reviews' can have its output in JSON format
+'workload' can have its output in JSON format
   -j : output each row as a JSON object.
        This is useful if you want to script & pipe the output.
        (--jsonlines is also accepted)
@@ -44,5 +46,5 @@ Usage: gh my [$ACTION_LIST] [options]
        default is whatever 'gh config get user -h github.com' returns
        ** Viewing security alerts implies permissions
 EOF
- exit 1
+  exit 1
 }

--- a/includes/query_issues
+++ b/includes/query_issues
@@ -1,31 +1,33 @@
 #!/usr/bin/env bash
 
-function query_issues() {
+query_issues() {
   # shellcheck disable=SC2016
-  query='query ($endCursor: String) {
-          search(query: "is:open is:issue user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
-            edges {
-              node {
-                ... on Issue {
-                  number
-                  title
-                  author {
-                    login
-                  }
-                  createdAt
-                  url
-                  repository {
-                    nameWithOwner
-                    name
-                  }
-                }
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+  local query='
+query ($endCursor: String) {
+  search(query: "is:open is:issue user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
+    edges {
+      node {
+        ... on Issue {
+          number
+          title
+          author {
+            login
           }
-        }'
-  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
+          createdAt
+          url
+          repository {
+            nameWithOwner
+            name
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}'
+  helper::std_output_format "$@"
+  helper::std_graphql "$query"
 }

--- a/includes/query_notifs
+++ b/includes/query_notifs
@@ -6,8 +6,8 @@ query_notifs() {
 {{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (hyperlink "https://github.com/notifications" (.subject.title | autocolor "yellow")) -}}
 {{end -}}'
 
-  notif_id=''
-  mark_all_as_read=''
+  local notif_id=''
+  local mark_all_as_read=''
   while getopts 'n:a' flag; do
     case "${flag}" in
     n) notif_id="${OPTARG}" ;;

--- a/includes/query_notifs
+++ b/includes/query_notifs
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-function query_notifs() {
-  notif_template='{{tablerow "ID" "Reason" "When" "Repo" "Title" -}}
+query_notifs() {
+  local notif_template='{{tablerow "ID" "Reason" "When" "Repo" "Title" -}}
 {{ range . -}}
 {{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (hyperlink "https://github.com/notifications" (.subject.title | autocolor "yellow")) -}}
 {{end -}}'

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -1,31 +1,33 @@
 #!/usr/bin/env bash
 
-function query_prs() {
+query_prs() {
   # shellcheck disable=SC2016
-  query='query ($endCursor: String) {
-          search(query: "is:open is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
-            edges {
-              node {
-                ... on PullRequest {
-                  number
-                  title
-                  author {
-                    login
-                  }
-                  createdAt
-                  url
-                  repository {
-                    nameWithOwner
-                    name
-                  }
-                }
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+  local query='
+query ($endCursor: String) {
+  search(query: "is:open is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
+    edges {
+      node {
+        ... on PullRequest {
+          number
+          title
+          author {
+            login
           }
-        }'
-  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
+          createdAt
+          url
+          repository {
+            nameWithOwner
+            name
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}'
+  helper::std_output_format "$@"
+  helper::std_graphql "$query"
 }

--- a/includes/query_report
+++ b/includes/query_report
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
 # Get all the issues & PRs involving by me in the last 14 days.
-function query_report() {
-  report_header='{{tablerow "Num" "Title" "Repository" "URL" "Last Activity" -}}'
-  report_data='
+query_report() {
+  local report_header='{{tablerow "Num" "Title" "Repository" "URL" "Last Activity" -}}'
+  local report_data='
 {{range(pluck "node" .data.search.edges) -}}
 {{tablerow (printf "#%v" .number | autocolor "green") .title (.repository.nameWithOwner | autocolor "yellow") (.url | autocolor "cyan") (timefmt "02-Jan" .updatedAt)  -}}
 {{end -}}
 {{tablerender}}
 '
   # This catches PRs where I have been requested as a reviewer, but I did nothing (CODEOWNER)
-  user_filter="involves:@me -user-review-requested:@me"
-  include_headers=true
-  since='14 days ago'
+  local user_filter="involves:@me -user-review-requested:@me"
+  local include_headers=true
+  local since='14 days ago'
+  local queryString
   while getopts 'd:qav' flag; do
     case "${flag}" in
     d) since="${OPTARG}" ;;
@@ -23,50 +24,49 @@ function query_report() {
     esac
   done
 
-  report_template="$report_data"
+  local report_template="$report_data"
   if [[ "$include_headers" == "true" ]]; then
     report_template="$report_header $report_data"
   fi
   queryString="$user_filter updated:>=$(date --date="$since" '+%Y-%m-%d') archived:false sort:updated"
   # shellcheck disable=SC2016
-  query='query ($queryString: String!, $endCursor: String){
-          search(query: $queryString,after: $endCursor, type: ISSUE, first: 50) {
-            edges {
-              node {
-                ... on PullRequest {
-                  number
-                  title
-                  author {
-                    login
-                  }
-                  reviewDecision
-                  updatedAt
-                  url
-                  repository {
-                    nameWithOwner
-                  }
-                }
-                ... on Issue {
-                  number
-                  title
-                  author {
-                    login
-                  }
-                  updatedAt
-                  url
-                  repository {
-                    nameWithOwner
-                  }
-                }
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+  local query='
+query ($queryString: String!, $endCursor: String){
+  search(query: $queryString,after: $endCursor, type: ISSUE, first: 50) {
+    edges {
+      node {
+        ... on PullRequest {
+          number
+          title
+          author {
+            login
           }
-        }'
-  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template "$report_template"
+          reviewDecision
+          updatedAt
+          url
+          repository {
+            nameWithOwner
+          }
+        }
+        ... on Issue {
+          number
+          title
+          author {
+            login
+          }
+          updatedAt
+          url
+          repository {
+            nameWithOwner
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}'
+  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$query")" --template "$report_template"
 }
-
-

--- a/includes/query_reviews
+++ b/includes/query_reviews
@@ -1,58 +1,34 @@
 #!/usr/bin/env bash
 
-function query_reviews() {
-
-  local format=""
-  local as_json='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "url": .url }'
-
-  for arg in "$@"; do
-    shift
-    case "$arg" in
-      --jsonlines|--json) set -- "$@" '-j';;
-      *) set -- "$@" "$arg";;
-    esac
-  done
-
-  while getopts 'j' flag; do
-    case "${flag}" in
-    j) format="json" ;;
-    *) query_help ;;
-    esac
-  done
-
+query_reviews() {
   # shellcheck disable=SC2016
-  local query='query ($endCursor: String){
-          search(query: "is:open is:pr review-requested:@me archived:false", after: $endCursor, type: ISSUE, first: 50) {
-            edges {
-              node {
-                ... on PullRequest {
-                  number
-                  title
-                  author {
-                     login
-                  }
-                  reviewDecision
-                  createdAt
-                  url
-                  repository {
-                    nameWithOwner
-                    name
-                  }
-                }
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+  local query='
+query ($endCursor: String){
+  search(query: "is:open is:pr review-requested:@me archived:false", after: $endCursor, type: ISSUE, first: 50) {
+    edges {
+      node {
+        ... on PullRequest {
+          number
+          title
+          author {
+             login
           }
-        }'
-  case $format in
-  json)
-    gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --jq "$as_json" | jq -c "."
-    ;;
-  *)
-    gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template="$TEMPLATE"
-    ;;
-  esac
+          reviewDecision
+          createdAt
+          url
+          repository {
+            nameWithOwner
+            name
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}'
+  helper::std_output_format "$@"
+  helper::std_graphql "$query"
 }

--- a/includes/query_vulns
+++ b/includes/query_vulns
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-function query_vulns() {
+query_vulns() {
 
   local whoami
   whoami=$(gh config get user -h github.com)
@@ -27,7 +27,8 @@ function query_vulns() {
 {{end -}}
 '
   # shellcheck disable=SC2016
-  local query='query($searchQuery: String!, $endCursor: String) {
+  local query='
+query($searchQuery: String!, $endCursor: String) {
   search(query: $searchQuery, type: REPOSITORY, first: 100, after: $endCursor) {
     edges {
       node {
@@ -55,7 +56,5 @@ function query_vulns() {
     }
   }
 }'
-  gh api graphql --paginate -F searchQuery="$queryString" --raw-field query="$(internal::compressQuery "$query")" --template="$template"
+  gh api graphql --paginate -F searchQuery="$queryString" --raw-field query="$(helper::compressQuery "$query")" --template="$template"
 }
-
-

--- a/includes/query_workload
+++ b/includes/query_workload
@@ -1,44 +1,46 @@
 #!/usr/bin/env bash
-function query_workload() {
+query_workload() {
   # shellcheck disable=SC2016
-  query='query ($endCursor: String){
-          search(query: "is:open assignee:@me archived:false",after: $endCursor, type: ISSUE, first: 50) {
-            edges {
-              node {
-                ... on PullRequest {
-                  number
-                  title
-                  author {
-                    login
-                  }
-                  reviewDecision
-                  createdAt
-                  url
-                  repository {
-                    nameWithOwner
-                    name
-                  }
-                }
-                ... on Issue {
-                  number
-                  title
-                  author {
-                    login
-                  }
-                  createdAt
-                  url
-                  repository {
-                    nameWithOwner
-                    name
-                  }
-                }
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+  local query='
+query ($endCursor: String){
+  search(query: "is:open assignee:@me archived:false",after: $endCursor, type: ISSUE, first: 50) {
+    edges {
+      node {
+        ... on PullRequest {
+          number
+          title
+          author {
+            login
           }
-        }'
-  gh api graphql --paginate --raw-field query="$(internal::compressQuery "$query")" --template "$TEMPLATE"
+          reviewDecision
+          createdAt
+          url
+          repository {
+            nameWithOwner
+            name
+          }
+        }
+        ... on Issue {
+          number
+          title
+          author {
+            login
+          }
+          createdAt
+          url
+          repository {
+            nameWithOwner
+            name
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}'
+  helper::std_output_format "$@"
+  helper::std_graphql "$query"
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Resolves #47

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- create a new helper_functions file that is sourced to provide shared functions
- enable -j for issues/workloads/prs since they follow the same model as reviews
- add justfile with recipe for linting (shellcheck + shfmt)
<!-- SQUASH_MERGE_END -->

## Testing

```
bsh ❯ ./gh-my issues -j
{"createdAt":"2024-02-23T17:03:43Z","login":"quotidian-ennui","number":47,"title":"Add --jsonlines support to other sub commands","url":"https://github.com/quotidian-ennui/gh-my/issues/47"}
{"createdAt":"2023-11-16T14:13:25Z","login":"quotidian-ennui","number":8,"title":"pr-or-issue-comment testing issue","url":"https://github.com/quotidian-ennui/actions-olio/issues/8"}
{"createdAt":"2021-03-02T01:18:10Z","login":"binge6","number":1,"title":"能增加Apple芯片支持吗？","url":"https://github.com/quotidian-ennui/homebrew-zulufx/issues/1"}
```

etc. for issues / prs / workload / reviews.