### PR TITLE
fix: workaround to ensure terminal hyperlink is terminated correctly

### DIFF
--- a/includes/query_notifs
+++ b/includes/query_notifs
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 query_notifs() {
-  local notif_template='{{tablerow "ID" "Reason" "When" "Repo" "Title" -}}
+  local notif_template='{{tablerow "ID" "Reason" "When" "Repo" "Title" "" -}}
 {{ range . -}}
-{{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (hyperlink "https://github.com/notifications" (.subject.title | autocolor "yellow")) -}}
+{{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (hyperlink "https://github.com/notifications" (.subject.title | autocolor "yellow")) ("\x1b]8;;\x1b\\") -}}
 {{end -}}'
 
   local notif_id=''


### PR DESCRIPTION
## Motivation

When testing a PR `gh notifs` hyperlink took over my terminal, which I raised #49 and https://github.com/cli/go-gh/issues/150. This works around the issue by ensuring its terminated.

I also considered just adding `printf '\e]8;;'` after line 21 

https://github.com/quotidian-ennui/gh-my/blob/58cdfb832f706886f240b03c803547b7b48f96f8/includes/query_notifs#L21

This would have at least stopped the command breaking the terminal, but each row was still broken

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- Add empty column
- Always print line closure
<!-- SQUASH_MERGE_END -->

## Thoughts

To be honest i'm not sure i like it, and possibly prefer just adding the print for the time being.

