### PR TITLE
fix!: remove hyperlink for notifs

### DIFF
--- a/includes/query_notifs
+++ b/includes/query_notifs
@@ -3,7 +3,7 @@
 query_notifs() {
   local notif_template='{{tablerow "ID" "Reason" "When" "Repo" "Title" -}}
 {{ range . -}}
-{{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (hyperlink "https://github.com/notifications" (.subject.title | autocolor "yellow")) -}}
+{{tablerow (.id | autocolor "green") (.reason | autocolor "cyan") (timeago .updated_at) (.repository.full_name) (.subject.title | autocolor "yellow") -}}
 {{end -}}'
 
   local notif_id=''


### PR DESCRIPTION
## Motivation

After discovering #49 we looked a little more into `hyperlink` function, it seems broken in the context of `tablerow`. As the link was for convivence its probably safer to remove.

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- remove use of hyperlink function in notifs command
<!-- SQUASH_MERGE_END -->