### PR TITLE
feat!: add json output to report+vulns

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ bsh ❯ gh my reviews -j | grep "bump hashicorp" | jq -c -r '.url' | xargs -L 1 
 bsh ❯ gh my reviews -j | grep "bump hashicorp" | jq -c -r '.url' | xargs -I {} bash -c "gh approve {} && gh squash-merge {}"
 ```
 
+- If you don't like JSON lines output then you can convert it into CSV if that's your bag since the keys are consistent across the output (normally you wouldn't be able to assume this with jsonl).
+
+```bash
+bsh ❯ gh my prs -j | jq --slurp | yq -p j -o csv
+createdAt,login,number,title,url
+2024-02-27T14:33:50Z,quotidian-ennui,52,feat: add json output to report+vulns,https://github.com/quotidian-ennui/gh-my/pull/52
+2024-02-26T03:20:48Z,qe-repo-updater,356,deps(java): bump quarkus to 3.7.4,https://github.com/quotidian-ennui/tesla-powerwall-exporter/pull/356
+2024-02-21T20:36:11Z,quotidian-ennui,72,feat!: switch to go-nv/goenv,https://github.com/quotidian-ennui/ubuntu-dpm/pull/72
+2024-02-19T09:03:13Z,qe-repo-updater,114,chore(deps): Bump gradle version to 8.6,https://github.com/quotidian-ennui/interlok-build-parent/pull/114
+```
+
 ## License
 
 See [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|w
   -q : omit the table headers
   -a : use 'author' instead of 'involves'
   -v : everything involving your user (e.g. where you're a CODEOWNER)
+  -j : output each row as a JSON object.
 
 'failures' uses 'date' so any gnu date string is valid
   -d : the date string (default is "14 days ago")
@@ -63,6 +64,7 @@ Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|w
   -o : the owner (e.g. -o my-company | -o my-user)
        default is whatever 'gh config get user -h github.com' returns
        ** Viewing security alerts implies permissions
+  -j : output each row as a JSON object.
 ```
 
 ```bash

--- a/gh-my
+++ b/gh-my
@@ -30,7 +30,7 @@ fi
 for arg in "$@"; do
   shift
   case "$arg" in
-  --jsonlines | --json) set -- "$@" '-j' ;;
+  --jsonlines | --jsonl) set -- "$@" '-j' ;;
   *) set -- "$@" "$arg" ;;
   esac
 done

--- a/includes/query_help
+++ b/includes/query_help
@@ -33,6 +33,7 @@ Usage: gh my [$ACTION_LIST] [options]
   -q : omit the table headers
   -a : use 'author' instead of 'involves'
   -v : everything involving your user (e.g. where you're a CODEOWNER)
+  -j : output each row as a JSON object.
 
 'failures' uses 'date' so any gnu date string is valid
   -d : the date string (default is "14 days ago")
@@ -45,6 +46,7 @@ Usage: gh my [$ACTION_LIST] [options]
   -o : the owner (e.g. -o my-company | -o my-user)
        default is whatever 'gh config get user -h github.com' returns
        ** Viewing security alerts implies permissions
+  -j : output each row as a JSON object.
 EOF
   exit 1
 }

--- a/includes/query_report
+++ b/includes/query_report
@@ -1,36 +1,15 @@
 #!/usr/bin/env bash
 
-# Get all the issues & PRs involving by me in the last 14 days.
-query_report() {
-  local report_header='{{tablerow "Num" "Title" "Repository" "URL" "Last Activity" -}}'
-  local report_data='
-{{range(pluck "node" .data.search.edges) -}}
-{{tablerow (printf "#%v" .number | autocolor "green") .title (.repository.nameWithOwner | autocolor "yellow") (.url | autocolor "cyan") (timefmt "02-Jan" .updatedAt)  -}}
-{{end -}}
-{{tablerender}}
-'
-  # This catches PRs where I have been requested as a reviewer, but I did nothing (CODEOWNER)
-  local user_filter="involves:@me -user-review-requested:@me"
-  local include_headers=true
-  local since='14 days ago'
-  local queryString
-  while getopts 'd:qav' flag; do
-    case "${flag}" in
-    d) since="${OPTARG}" ;;
-    a) user_filter="author:@me" ;;
-    v) user_filter="involves:@me" ;;
-    q) include_headers=false ;;
-    *) query_help ;;
-    esac
-  done
-
-  local report_template="$report_data"
-  if [[ "$include_headers" == "true" ]]; then
-    report_template="$report_header $report_data"
-  fi
-  queryString="$user_filter updated:>=$(date --date="$since" '+%Y-%m-%d') archived:false sort:updated"
-  # shellcheck disable=SC2016
-  local query='
+# shellcheck disable=SC2016
+REPORT_JSON_JQ='.data.search.edges[] | .node |
+  {
+    "number":.number,
+    "title": .title, "repository":
+    .repository.nameWithOwner,
+    "url": .url,
+    "updatedAt": .updatedAt
+  }'
+REPORT_GRAPHQL_QUERY='
 query ($queryString: String!, $endCursor: String){
   search(query: $queryString,after: $endCursor, type: ISSUE, first: 50) {
     edges {
@@ -67,6 +46,55 @@ query ($queryString: String!, $endCursor: String){
       endCursor
     }
   }
-}'
-  gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$query")" --template "$report_template"
+}
+'
+
+# Get all the issues & PRs involving by me in the last 14 days.
+query_report() {
+
+  # This catches PRs where I have been requested as a reviewer, but I did nothing (CODEOWNER)
+  local user_filter="involves:@me -user-review-requested:@me"
+  local include_headers=true
+  local since='14 days ago'
+  local output_format="table"
+  local queryString
+  local report_template
+
+  while getopts 'd:qavj' flag; do
+    case "${flag}" in
+    d) since="${OPTARG}" ;;
+    j) output_format="json" ;;
+    a) user_filter="author:@me" ;;
+    v) user_filter="involves:@me" ;;
+    q) include_headers=false ;;
+    *) query_help ;;
+    esac
+  done
+
+  report_template="$(private::report_table_template "$include_headers")"
+  queryString="$user_filter updated:>=$(date --date="$since" '+%Y-%m-%d') archived:false sort:updated"
+  case $output_format in
+  json)
+    gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$REPORT_GRAPHQL_QUERY")" --jq "$REPORT_JSON_JQ" | jq -c "."
+    ;;
+  *)
+    gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$REPORT_GRAPHQL_QUERY")" --template "$report_template"
+    ;;
+  esac
+}
+
+private::report_table_template() {
+  local report_header='{{tablerow "Num" "Title" "Repository" "URL" "Last Activity" -}}'
+  local report_data='
+{{range(pluck "node" .data.search.edges) -}}
+{{tablerow (printf "#%v" .number | autocolor "green") .title (.repository.nameWithOwner | autocolor "yellow") (.url | autocolor "cyan") (timefmt "02-Jan" .updatedAt)  -}}
+{{end -}}
+{{tablerender}}
+'
+  local report_template="$report_data"
+  local include_headers="$1"
+  if [[ "$include_headers" == "true" ]]; then
+    report_template="$report_header $report_data"
+  fi
+  echo "$report_template"
 }

--- a/includes/query_vulns
+++ b/includes/query_vulns
@@ -1,33 +1,32 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-query_vulns() {
+# shellcheck disable=SC2016
+VULNS_JSON_JQ='
+.data.search.edges[] | .node.vulnerabilityAlerts.nodes.[] |
+{
+    "repository": .repository.nameWithOwner,
+    "package": .securityVulnerability.package.name,
+    "url": "http://github.com/\(.repository.nameWithOwner)/security/dependabot/\(.number)",
+    "createdAt": .createdAt
+}
+'
 
-  local whoami
-  whoami=$(gh config get user -h github.com)
-  while getopts 'o:' flag; do
-    case "${flag}" in
-    o) whoami="${OPTARG}" ;;
-    *) query_help ;;
-    esac
-  done
-
-  local queryString="owner:$whoami archived:false"
-  # shellcheck disable=SC2016
-  local template='{{tablerow "Repository" "Package" "URL" "Created" -}}
+# shellcheck disable=SC2016
+VULNS_REPORT_TEMPLATE='
+{{tablerow "Repository" "Package" "URL" "Created" -}}
 {{range(pluck "node" .data.search.edges) -}}
-{{ $repo:=.nameWithOwner -}}
 {{range .vulnerabilityAlerts.nodes -}}
-{{ $url:= printf "https://github.com/%s/security/dependabot/%v" $repo .number -}}
-{{tablerow ($repo | autocolor "green")
+{{ $url:= printf "https://github.com/%s/security/dependabot/%v" .repository.nameWithOwner .number -}}
+{{tablerow (.repository.nameWithOwner | autocolor "green")
           (.securityVulnerability.package.name | autocolor "cyan")
           ($url | autocolor "yellow")
           (timeago .createdAt) -}}
 {{end -}}
 {{end -}}
 '
-  # shellcheck disable=SC2016
-  local query='
+# shellcheck disable=SC2016
+VULNS_GRAPHQL_QUERY='
 query($searchQuery: String!, $endCursor: String) {
   search(query: $searchQuery, type: REPOSITORY, first: 100, after: $endCursor) {
     edges {
@@ -40,6 +39,9 @@ query($searchQuery: String!, $endCursor: String) {
               vulnerableManifestPath
               vulnerableManifestFilename
               number
+              repository {
+                nameWithOwner
+              }
               securityVulnerability {
                 package {
                   name
@@ -55,6 +57,29 @@ query($searchQuery: String!, $endCursor: String) {
       endCursor
     }
   }
-}'
-  gh api graphql --paginate -F searchQuery="$queryString" --raw-field query="$(helper::compressQuery "$query")" --template="$template"
+}
+'
+
+query_vulns() {
+
+  local whoami
+  local output_format="table"
+  whoami=$(gh config get user -h github.com)
+  while getopts 'o:j' flag; do
+    case "${flag}" in
+    j) output_format="json" ;;
+    o) whoami="${OPTARG}" ;;
+    *) query_help ;;
+    esac
+  done
+
+  local queryString="owner:$whoami archived:false"
+  case $output_format in
+  json)
+    gh api graphql --paginate -F searchQuery="$queryString" --raw-field query="$(helper::compressQuery "$VULNS_GRAPHQL_QUERY")" --jq="$VULNS_JSON_JQ" | jq -c "."
+    ;;
+  *)
+    gh api graphql --paginate -F searchQuery="$queryString" --raw-field query="$(helper::compressQuery "$VULNS_GRAPHQL_QUERY")" --template="$VULNS_REPORT_TEMPLATE"
+    ;;
+  esac
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Additional work for #47

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add jsonlines to report
- add jsonlines to vulns
- changed the graphql query in vulns to be more amenable to JQ
- added short note on how to convert to CSV

BREAKING CHANGE: --json renamed to --jsonl which is more precise

<!-- SQUASH_MERGE_END -->

## Testing

Existing commands and functionality should work but now with the capability of adding -j to emit jsonlines output.

```
bsh ❯ gh my report -j -d "1 day ago"
{"number":52,"repository":"quotidian-ennui/gh-my","title":"feat: add json output to report+vulns","updatedAt":"2024-02-27T14:35:48Z","url":"https://github.com/quotidian-ennui/gh-my/pull/52"}
{"number":49,"repository":"quotidian-ennui/gh-my","title":"gh notifs hyperlink isn't terminated correctly if output is truncated","updatedAt":"2024-02-27T14:34:42Z","url":"https://github.com/quotidian-ennui/gh-my/issues/49"}


bsh ❯ gh my vulns -o adaptris -j
{"createdAt":"2023-05-23T00:23:44Z","package":"gradle/gradle-build-action","repository":"adaptris/interlok-build-parent","url":"http://github.com/adaptris/interlok-build-parent/security/dependabot/2"}
```
