### PR TITLE
feat: add statusCheckRollup to query_prs

### DIFF
--- a/includes/query_prs
+++ b/includes/query_prs
@@ -2,6 +2,7 @@
 
 query_prs() {
   #shellcheck disable=SC2034
+  #shellcheck disable=SC2016
   local table_template='{{tablerow "Status" "Num" "Title" "Who" "URL" "When" -}}
   {{range(pluck "node" .data.search.edges) -}}
   {{ if index . "statusCheckRollup" -}}
@@ -15,8 +16,8 @@ query_prs() {
   {{ end -}}
   {{end -}}
   {{tablerender}}'
-  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "url": .url, "createdAt": .createdAt}'
 
+  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "url": .url, "createdAt": .createdAt}'
   # shellcheck disable=SC2016
   local query='
 query ($endCursor: String) {

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
 query_prs() {
+  #shellcheck disable=SC2034
+  local table_template='{{tablerow "Status" "Num" "Title" "Who" "URL" "When" -}}
+  {{range(pluck "node" .data.search.edges) -}}
+  {{tablerow .statusCheckRollup.state (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+  {{end -}}
+  {{tablerender}}'
+  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "url": .url, "createdAt": .createdAt}'
+
   # shellcheck disable=SC2016
   local query='
 query ($endCursor: String) {
@@ -19,6 +27,9 @@ query ($endCursor: String) {
             nameWithOwner
             name
           }
+          statusCheckRollup {
+            state
+          }
         }
       }
     }
@@ -28,6 +39,19 @@ query ($endCursor: String) {
     }
   }
 }'
-  helper::std_output_format "$@"
-  helper::std_graphql "$query"
+
+  while getopts 'j' flag; do
+    case "${flag}" in
+    j) output_format="json" ;;
+    *) query_help ;;
+    esac
+  done
+  case $output_format in
+  json)
+    gh api graphql --paginate --raw-field query="$(helper::compressQuery "$query")" --jq "$jq_filter" | jq -c "."
+    ;;
+  *)
+    gh api graphql --paginate --raw-field query="$(helper::compressQuery "$query")" --template "$table_template"
+    ;;
+  esac
 }

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -4,7 +4,15 @@ query_prs() {
   #shellcheck disable=SC2034
   local table_template='{{tablerow "Status" "Num" "Title" "Who" "URL" "When" -}}
   {{range(pluck "node" .data.search.edges) -}}
-  {{tablerow .statusCheckRollup.state (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+  {{ if index . "statusCheckRollup" -}}
+    {{ $colour := "green" -}}
+    {{ if ne .statusCheckRollup.state "SUCCESS" -}}
+      {{ $colour = "red" -}}
+    {{ end -}}
+    {{tablerow (.statusCheckRollup.state | autocolor $colour) (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+  {{ else -}}
+    {{tablerow ("UNKNOWN" | autocolor "yellow") (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+  {{ end -}}
   {{end -}}
   {{tablerender}}'
   local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "url": .url, "createdAt": .createdAt}'
@@ -12,7 +20,7 @@ query_prs() {
   # shellcheck disable=SC2016
   local query='
 query ($endCursor: String) {
-  search(query: "is:open is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
+  search(query: "is:closed is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
     edges {
       node {
         ... on PullRequest {

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -20,7 +20,7 @@ query_prs() {
   # shellcheck disable=SC2016
   local query='
 query ($endCursor: String) {
-  search(query: "is:closed is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
+  search(query: "is:open is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
     edges {
       node {
         ... on PullRequest {


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
List your prs including a status rollup check so you can easily see which ones haven't passed your workflow actions

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add statusRollupCheck to query
- no statusRollupCheck == 'UNKNOWN'
- colorize the status Red(fail+pending)/Yellow(unknown)/Green(success)
<!-- SQUASH_MERGE_END -->

## Testing

```bash
bsh ❯ gh my prs
Status   Num   Title                                       Who              URL                                                     When
SUCCESS  #63   feat: add statusCheckRollup to query        quotidian-ennui  https://github.com/quotidian-ennui/gh-my/pull/63        4 minutes ago
FAILURE  #164  chore(deps): Bump golang version to 1.22.3  qe-repo-updater  https://github.com/quotidian-ennui/ubuntu-dpm/pull/164  18 minutes ago
```

```bash
bsh ❯ gh my prs --jsonlines
{"createdAt":"2024-05-08T08:02:28Z","login":"quotidian-ennui","number":63,"statusRollup":"SUCCESS","title":"feat: add statusCheckRollup to query","url":"https://github.com/quotidian-ennui/gh-my/pull/63"}
{"createdAt":"2024-05-08T07:48:13Z","login":"qe-repo-updater","number":164,"statusRollup":"FAILURE","title":"chore(deps): Bump golang version to 1.22.3","url":"https://github.com/quotidian-ennui/ubuntu-dpm/pull/164"}
```

