### PR TITLE
feat(prs)!: switch to repo first behaviour for query_prs

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -52,7 +52,7 @@ jobs:
       github.event_name == 'pull_request'
     steps:
       - run: |
-          regexp="^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|deps)(\(.+\))?: "
+          regexp="^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|deps)(\(.+\))?(!)?: "
           title="${{ github.event.pull_request.title }}"
           if [[ ! $title =~ $regexp ]]; then
             echo "PR Title is not 'conventional' matching $regexp" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -13,6 +13,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'edited'
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.5
@@ -32,7 +35,8 @@ jobs:
       contents: read
       pull-requests: write
     if: |
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' &&
+      github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4.1.5
         with:
@@ -49,7 +53,8 @@ jobs:
       contents: read
       pull-requests: read
     if: |
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'edited' || github.event.action == 'opened')
     steps:
       - run: |
           regexp="^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|deps)(\(.+\))?(!)?: "
@@ -64,6 +69,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4.1.5
       - name: typos

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ This is an extension for [GitHub CLI](https://cli.github.com/) that just lists a
 ## Installation
 
 Prerequisites:
- - [GitHub CLI](https://cli.github.com/) is already installed and authenticated
- - [`jq`](https://stedolan.github.io/jq/) is installed
- - `column` which is a standard linux tool; already present in _git+bash_ on windows; via _util-linux_ on ubuntu.
- - `date` needs to support the `--date "14 days ago"` style option.
+
+- [GitHub CLI](https://cli.github.com/) is already installed and authenticated
+- [`jq`](https://stedolan.github.io/jq/) is installed
+- `column` which is a standard linux tool; already present in _git+bash_ on windows; via _util-linux_ on ubuntu.
+- `date` needs to support the `--date "14 days ago"` style option.
 
 To install this extension:
 
@@ -20,10 +21,12 @@ gh extension install quotidian-ennui/gh-my
 
 ## Usage
 
-```
+```shell
+bsh ❯ gh my
+
 Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|workload] [options]
   issues      : list issues in your personal repositories
-  prs         : list PRs in your persional repositories
+  prs         : list PRs in the current repository or all your personal repos
   reviews     : list PRs where you've been asked for a review
   workload    : list PRs and issues where you are the assignee
   deployments : list deployments awaiting action on the default branch
@@ -34,12 +37,18 @@ Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|w
   vulns       : show vulnerability alerts from dependabot in your personal repositories
 
 'issues' can have its output in JSON format
-'prs' can have its output in JSON format
 'reviews' can have its output in JSON format
 'workload' can have its output in JSON format
   -j : output each row as a JSON object.
        This is useful if you want to script & pipe the output.
        (--jsonlines is also accepted)
+
+'prs' shows the PRs in the current repo by default.
+  -a : PRs in all your personal repositories
+       This is the default behaviour if your current location
+       is not a github repo and should be explicitly set if
+       it is.
+  -j : output each row as a JSON object.
 
 'deployments' needs more filters
   -o : the organisation (e.g. -o my-company)
@@ -80,7 +89,7 @@ bsh ❯ gh my issues -j
 
 ### deployments
 
-Because of https://github.com/quotidian-ennui/gh-my/issues/2 you can now list deployments that are waiting for someone to approve them (perhaps you're doing something like this : https://warman.io/blog/2023/03/fixing-automating-terraform-with-github-actions/). The usage model is geared towards you filtering either explicitly by repository (in which case you can probably do `gh run list -R <repo> -s "waiting"` instead, but is present for completeness) or by organisation + topic.
+Because of <https://github.com/quotidian-ennui/gh-my/issues/2> you can now list deployments that are waiting for someone to approve them (perhaps you're doing something like this : <https://warman.io/blog/2023/03/fixing-automating-terraform-with-github-actions/>). The usage model is geared towards you filtering either explicitly by repository (in which case you can probably do `gh run list -R <repo> -s "waiting"` instead, but is present for completeness) or by organisation + topic.
 
 ```bash
 bsh ❯ gh my deployments -o telus-agcg -t tpm-demeter
@@ -105,12 +114,12 @@ bsh ❯ gh my reviews -j | grep "bump hashicorp" | jq -c -r '.url' | xargs -I {}
 - If you don't like JSON lines output then you can convert it into CSV if that's your bag since the keys are consistent across the output (normally you wouldn't be able to assume this with jsonl).
 
 ```bash
-bsh ❯ gh my prs -j | jq --slurp | yq -p j -o csv
-createdAt,login,number,title,url
-2024-02-27T14:33:50Z,quotidian-ennui,52,feat: add json output to report+vulns,https://github.com/quotidian-ennui/gh-my/pull/52
-2024-02-26T03:20:48Z,qe-repo-updater,356,deps(java): bump quarkus to 3.7.4,https://github.com/quotidian-ennui/tesla-powerwall-exporter/pull/356
-2024-02-21T20:36:11Z,quotidian-ennui,72,feat!: switch to go-nv/goenv,https://github.com/quotidian-ennui/ubuntu-dpm/pull/72
-2024-02-19T09:03:13Z,qe-repo-updater,114,chore(deps): Bump gradle version to 8.6,https://github.com/quotidian-ennui/interlok-build-parent/pull/114
+bsh ❯ gh my prs -j -a | jq --slurp | yq -p j -o csv
+createdAt,login,number,statusRollup,title,url
+2024-05-08T12:24:37Z,mcwarman,15,SUCCESS,feat: add checkout command to switch branches,https://github.com/quotidian-ennui/bitbucket-pr/pull/15
+2024-05-08T11:28:20Z,qe-repo-updater,26,SUCCESS,chore(deps): Bump Apache Parquet-MR version to 1.14.0,https://github.com/quotidian-ennui/parquet-cli-wrapper/pull/26
+2024-05-08T10:23:56Z,mcwarman,165,SUCCESS,feat: add jsonschema2pojo,https://github.com/quotidian-ennui/ubuntu-dpm/pull/165
+2024-05-08T07:48:13Z,qe-repo-updater,164,FAILURE,chore(deps): Bump golang version to 1.22.3,https://github.com/quotidian-ennui/ubuntu-dpm/pull/164
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Prerequisites:
 
 To install this extension:
 
-```
+```bash
 gh extension install quotidian-ennui/gh-my
 ```
 
 ## Usage
 
-```shell
+```text
 bsh ❯ gh my
 
 Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|workload] [options]
@@ -113,13 +113,14 @@ bsh ❯ gh my reviews -j | grep "bump hashicorp" | jq -c -r '.url' | xargs -I {}
 
 - If you don't like JSON lines output then you can convert it into CSV if that's your bag since the keys are consistent across the output (normally you wouldn't be able to assume this with jsonl).
 
-```bash
+```text
 bsh ❯ gh my prs -j -a | jq --slurp | yq -p j -o csv
-createdAt,login,number,statusRollup,title,url
-2024-05-08T12:24:37Z,mcwarman,15,SUCCESS,feat: add checkout command to switch branches,https://github.com/quotidian-ennui/bitbucket-pr/pull/15
-2024-05-08T11:28:20Z,qe-repo-updater,26,SUCCESS,chore(deps): Bump Apache Parquet-MR version to 1.14.0,https://github.com/quotidian-ennui/parquet-cli-wrapper/pull/26
-2024-05-08T10:23:56Z,mcwarman,165,SUCCESS,feat: add jsonschema2pojo,https://github.com/quotidian-ennui/ubuntu-dpm/pull/165
-2024-05-08T07:48:13Z,qe-repo-updater,164,FAILURE,chore(deps): Bump golang version to 1.22.3,https://github.com/quotidian-ennui/ubuntu-dpm/pull/164
+createdAt,login,number,reviewDecision,statusRollup,title,url
+2024-05-08T16:00:37Z,quotidian-ennui,64,null,SUCCESS,feat(prs)!: switch to repo first behaviour for query_prs,https://github.com/quotidian-ennui/gh-my/pull/64
+2024-05-08T12:24:37Z,mcwarman,15,CHANGES_REQUESTED,SUCCESS,feat: add checkout command to switch branches,https://github.com/quotidian-ennui/bitbucket-pr/pull/15
+2024-05-08T11:28:20Z,qe-repo-updater,26,APPROVED,SUCCESS,chore(deps): Bump Apache Parquet-MR version to 1.14.0,https://github.com/quotidian-ennui/parquet-cli-wrapper/pull/26
+2024-05-08T10:23:56Z,mcwarman,165,null,SUCCESS,feat: add jsonschema2pojo,https://github.com/quotidian-ennui/ubuntu-dpm/pull/165
+2024-05-08T07:48:13Z,qe-repo-updater,164,null,FAILURE,chore(deps): Bump golang version to 1.22.3,https://github.com/quotidian-ennui/ubuntu-dpm/pull/164
 ```
 
 ## License

--- a/includes/helper_functions
+++ b/includes/helper_functions
@@ -42,3 +42,11 @@ helper::std_graphql() {
     ;;
   esac
 }
+
+helper::giturl_to_base () {
+  local url=$1
+  url=${url%%.git}
+  url=${url#*github.com:}
+  url=${url#*github.com/}
+  echo "$url"
+}

--- a/includes/query_help
+++ b/includes/query_help
@@ -5,7 +5,7 @@ query_help() {
 
 Usage: gh my [$ACTION_LIST] [options]
   issues      : list issues in your personal repositories
-  prs         : list PRs in your persional repositories
+  prs         : list PRs in the current repository or all your personal repos
   reviews     : list PRs where you've been asked for a review
   workload    : list PRs and issues where you are the assignee
   deployments : list deployments awaiting action on the default branch
@@ -16,12 +16,18 @@ Usage: gh my [$ACTION_LIST] [options]
   vulns       : show vulnerability alerts from dependabot in your personal repositories
 
 'issues' can have its output in JSON format
-'prs' can have its output in JSON format
 'reviews' can have its output in JSON format
 'workload' can have its output in JSON format
   -j : output each row as a JSON object.
        This is useful if you want to script & pipe the output.
        (--jsonlines is also accepted)
+
+'prs' shows the PRs in the current repo by default.
+  -a : PRs in all your personal repositories
+       This is the default behaviour if your current location
+       is not a github repo and should be explicitly set if
+       it is.
+  -j : output each row as a JSON object.
 
 'deployments' needs more filters
   -o : the organisation (e.g. -o my-company)

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -14,9 +14,9 @@ _prs_repo_query() {
 query_prs() {
   #shellcheck disable=SC2034
   #shellcheck disable=SC2016
-  local table_template='{{tablerow "" "" "Num" "Title" "Who" "URL" "When" -}}
+  local table_template='{{tablerow "" "Num" "Title" "Who" "URL" "When" -}}
   {{range(pluck "node" .data.search.edges) -}}
-  {{ $review := "⁉️" -}}
+  {{ $review := "❔" -}}
   {{ $status := "❔" -}}
   {{ if index . "reviewDecision" -}}
     {{ if eq .reviewDecision "CHANGES_REQUESTED" -}}
@@ -40,11 +40,15 @@ query_prs() {
       {{ $status = "✅" -}}
     {{ end -}}
   {{ end -}}
-  {{tablerow $status $review (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+  {{ $draft := "🛫" -}}
+  {{ if eq .isDraft true -}}
+    {{ $draft = "🔨" -}}
+  {{ end -}}
+  {{tablerow ( printf "%s%s%s" $status $review $draft) (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
   {{end -}}
   {{tablerender}}'
 
-  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "reviewDecision": .reviewDecision, "url": .url, "createdAt": .createdAt}'
+  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "reviewDecision": .reviewDecision, "isDraft": .isDraft, "url": .url, "createdAt": .createdAt}'
   # shellcheck disable=SC2016
   local query='
 query ($queryString: String!,$endCursor: String) {
@@ -67,6 +71,7 @@ query ($queryString: String!,$endCursor: String) {
             state
           }
           reviewDecision
+          isDraft
         }
       }
     }

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
 
+PR_ALL_REPOS_QUERY="is:open is:pr user:@me archived:false"
+
+_prs_repo_query() {
+  gitRemote=$(git remote get-url origin 2>/dev/null | grep "github.com" | cut -f2 -d':') || true
+  if [[ -n "$gitRemote" ]]; then
+    echo "is:open is:pr repo:$gitRemote archived:false"
+  else
+    echo "$PR_ALL_REPOS_QUERY"
+  fi
+}
+
 query_prs() {
   #shellcheck disable=SC2034
   #shellcheck disable=SC2016
-  local table_template='{{tablerow "Status" "Num" "Title" "Who" "URL" "When" -}}
+  local table_template='{{tablerow "" "Num" "Title" "Who" "URL" "When" -}}
   {{range(pluck "node" .data.search.edges) -}}
   {{ if index . "statusCheckRollup" -}}
-    {{ $colour := "green" -}}
-    {{ if ne .statusCheckRollup.state "SUCCESS" -}}
-      {{ $colour = "red" -}}
+    {{ $status := "❔" -}}
+    {{ if eq .statusCheckRollup.state "PENDING" -}}
+      {{ $status = "⏱️" -}}
     {{ end -}}
-    {{tablerow (.statusCheckRollup.state | autocolor $colour) (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+    {{ if eq .statusCheckRollup.state "FAILURE" -}}
+      {{ $status = "⛔" -}}
+    {{ end -}}
+    {{ if eq .statusCheckRollup.state "SUCCESS" -}}
+      {{ $status = "✅" -}}
+    {{ end -}}
+    {{tablerow ($status ) (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
   {{ else -}}
-    {{tablerow ("UNKNOWN" | autocolor "yellow") (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
+    {{tablerow ("❔") (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
   {{ end -}}
   {{end -}}
   {{tablerender}}'
@@ -20,8 +37,8 @@ query_prs() {
   local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "url": .url, "createdAt": .createdAt}'
   # shellcheck disable=SC2016
   local query='
-query ($endCursor: String) {
-  search(query: "is:open is:pr user:@me archived:false", type: ISSUE, after: $endCursor, first: 50) {
+query ($queryString: String!,$endCursor: String) {
+  search(query: $queryString, type: ISSUE, after: $endCursor, first: 50) {
     edges {
       node {
         ... on PullRequest {
@@ -49,18 +66,21 @@ query ($endCursor: String) {
   }
 }'
 
-  while getopts 'j' flag; do
+  local queryString
+  queryString=$(_prs_repo_query)
+  while getopts 'ja' flag; do
     case "${flag}" in
     j) output_format="json" ;;
+    a) queryString="$PR_ALL_REPOS_QUERY" ;;
     *) query_help ;;
     esac
   done
   case $output_format in
   json)
-    gh api graphql --paginate --raw-field query="$(helper::compressQuery "$query")" --jq "$jq_filter" | jq -c "."
+    gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$query")" --jq "$jq_filter" | jq -c "."
     ;;
   *)
-    gh api graphql --paginate --raw-field query="$(helper::compressQuery "$query")" --template "$table_template"
+    gh api graphql --paginate -F queryString="$queryString" --raw-field query="$(helper::compressQuery "$query")" --template "$table_template"
     ;;
   esac
 }

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -14,10 +14,22 @@ _prs_repo_query() {
 query_prs() {
   #shellcheck disable=SC2034
   #shellcheck disable=SC2016
-  local table_template='{{tablerow "" "Num" "Title" "Who" "URL" "When" -}}
+  local table_template='{{tablerow "" "" "Num" "Title" "Who" "URL" "When" -}}
   {{range(pluck "node" .data.search.edges) -}}
+  {{ $review := "⁉️" -}}
+  {{ $status := "❔" -}}
+  {{ if index . "reviewDecision" -}}
+    {{ if eq .reviewDecision "CHANGES_REQUESTED" -}}
+      {{ $review = "✒️" -}}
+    {{ end -}}
+    {{ if eq .statusCheckRollup.state "REVIEW_REQUIRED" -}}
+      {{ $review = "🔎" -}}
+    {{ end -}}
+    {{ if eq .reviewDecision "APPROVED" -}}
+      {{ $review = "👍" -}}
+    {{ end -}}
+  {{ end -}}
   {{ if index . "statusCheckRollup" -}}
-    {{ $status := "❔" -}}
     {{ if eq .statusCheckRollup.state "PENDING" -}}
       {{ $status = "⏱️" -}}
     {{ end -}}
@@ -27,14 +39,12 @@ query_prs() {
     {{ if eq .statusCheckRollup.state "SUCCESS" -}}
       {{ $status = "✅" -}}
     {{ end -}}
-    {{tablerow ($status ) (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
-  {{ else -}}
-    {{tablerow ("❔") (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
   {{ end -}}
+  {{tablerow $status $review (printf "#%v" .number | autocolor "green") .title .author.login (.url | autocolor "cyan") (timeago .createdAt)  -}}
   {{end -}}
   {{tablerender}}'
 
-  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "url": .url, "createdAt": .createdAt}'
+  local jq_filter='.data.search.edges[] | .node | { "number":.number, "title": .title, "login": .author.login, "statusRollup": .statusCheckRollup.state, "reviewDecision": .reviewDecision, "url": .url, "createdAt": .createdAt}'
   # shellcheck disable=SC2016
   local query='
 query ($queryString: String!,$endCursor: String) {
@@ -56,6 +66,7 @@ query ($queryString: String!,$endCursor: String) {
           statusCheckRollup {
             state
           }
+          reviewDecision
         }
       }
     }

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -4,6 +4,7 @@ PR_ALL_REPOS_QUERY="is:open is:pr user:@me archived:false"
 
 _prs_repo_query() {
   gitRemote=$(git remote get-url origin 2>/dev/null | grep "github.com" | cut -f2 -d':') || true
+  gitRemote=$(helper::giturl_to_base "$gitRemote")
   if [[ -n "$gitRemote" ]]; then
     echo "is:open is:pr repo:$gitRemote archived:false"
   else


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Since `gh pr list` doesn't show you the status of your workflows (`gh pr list --json "statusCheckRollup"` gives you a JSON array, it might be useful to use `gh-my` to show you the URL & status of the PRs in the current repository.

This turns the previous behaviour on its head, since it only ever worked with all your personal repositories.

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add '-a' flag for explicit 'all personal repos' behaviour
- defaults to local repo prs if it is a github repo
- defaults to all personal repos if not a github repo or not a git repo.
- add draft status
- add approved status
- uses emojis rather than the text to display statuses
- fixes the workflow that checks the PR title

BREAKING CHANGE: gh my prs now defaults to local repository by default
<!-- SQUASH_MERGE_END -->

## Testing

```shell
bsh ❯ gh my prs -a
        Num   Title                                   Who              URL                                     When
✅❔🛫  #64   feat(prs)!: switch to repo first be...  quotidian-ennui  https://github.com/quotidian-ennui/...  1 day ago
✅❔🔨  #165  feat: add jsonschema2pojo               mcwarman         https://github.com/quotidian-ennui/...  1 day ago
✅👍🛫  #164  chore(deps): Bump golang version to...  qe-repo-updater  https://github.com/quotidian-ennui/...  1 day ago
```

- ✅ status rollup indicates a success (or ⛔ failure, ⏱️ pending, ❔indeterminate)
- 👍 PR is approved (✒️ - changes requested, 🔎 review required, ❔indeterminate)
- 🛫 ready for review, 🔨 draft
