### PR TITLE
fix(prs): fix copy-paste typo referring to statusCheck

### DIFF
--- a/includes/query_prs
+++ b/includes/query_prs
@@ -23,7 +23,7 @@ query_prs() {
     {{ if eq .reviewDecision "CHANGES_REQUESTED" -}}
       {{ $review = "✒️" -}}
     {{ end -}}
-    {{ if eq .statusCheckRollup.state "REVIEW_REQUIRED" -}}
+    {{ if eq .reviewDecision "REVIEW_REQUIRED" -}}
       {{ $review = "🔎" -}}
     {{ end -}}
     {{ if eq .reviewDecision "APPROVED" -}}


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

Resolves #75 

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- fix typo that referred to .statusCheckRollup.state
<!-- SQUASH_MERGE_END -->

