### PR TITLE
refactor: change review_decision default emoji

### DIFF
--- a/includes/query_prs
+++ b/includes/query_prs
@@ -12,13 +12,17 @@ _prs_repo_query() {
   fi
 }
 
+# Because of https://github.com/orgs/community/discussions/24375
+# reviewDecision will only be populated IF a review is 'required'
+# otherwise it defaults to null. ? in that context is potentially
+# a distracting emoji.
 query_prs() {
   #shellcheck disable=SC2034
   #shellcheck disable=SC2016
   local table_template='{{tablerow "" "Num" "Title" "Who" "URL" "When" -}}
   {{range(pluck "node" .data.search.edges) -}}
-  {{ $review := "❔" -}}
   {{ $status := "❔" -}}
+  {{ $review := "🌤️" -}}
   {{ if index . "reviewDecision" -}}
     {{ if eq .reviewDecision "CHANGES_REQUESTED" -}}
       {{ $review = "✒️" -}}


### PR DESCRIPTION
## Motivation

Based on docs (via `https://github.com/orgs/community/discussions/24375`). `reviewDecision` will be null unless a review is required for a pull-request. It will be null if a review decision is not actually required to merge the PR.

For that reason, it feels like we should change the emoji from the default question mark to something a bit less stark

## Changes

<!-- SQUASH_MERGE_START -->
- change default emoji to sunny/cloudy combo
<!-- SQUASH_MERGE_END -->

## Result 

It will now look this, if the repo has not been configured with a strict review policy

```
bsh ❯ gh my prs -a
✅🌤️🛫  #351  chore(deps): Bump gitleaks/gitleaks version to v8.19.1               qe-repo-updater  https://github.com/quotidian-ennui/ubuntu-dpm/pull/351                9 hours ago
```
