### PR TITLE
feat: add -g mode to show all orgs for failures

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+## Review Style
+- Be specific and actionable in feedback.
+- Explain the "why" behind recommendations.
+- Always prioritize security vulnerabilities and performance issues that could impact users.
+- Never suggest changes to improve readability.
+- Never suggest changes related to platform variants for GNU tooling.
+
+## General Principles
+
+- Use shellcheck for static analysis when available
+- Prefer safe expansions: double-quote variable references (`"$var"`), use `${var}` for clarity, and avoid `eval`
+- Use modern Bash features (`[[ ]]`, `local`, arrays) when portability requirements allow; fall back to POSIX constructs only when needed
+- Choose reliable parsers for structured data instead of ad-hoc text processing
+
+## Script Structure
+
+- Start with a clear shebang: `#!/usr/bin/env bash` unless specified otherwise
+- Include a header comment explaining the script's purpose
+- Define default values for all variables at the top
+- Use functions for reusable code blocks
+- Create reusable functions instead of repeating similar blocks of code
+- Keep the main execution flow clean and readable
+
+## Working with JSON and YAML
+
+- Prefer dedicated parsers (`jq` for JSON, `yq` for YAML—or `jq` on JSON converted via `yq`) over ad-hoc text processing with `grep`, `awk`, or shell string splitting
+- Validate that required fields exist and handle missing/invalid data paths explicitly (e.g., by checking `jq` exit status or using `// empty`)
+- Quote jq/yq filters to prevent shell expansion and prefer `--raw-output` when you need plain strings
+- Treat parser errors as fatal: combine with `set -euo pipefail` or test command success before using results
+- Document parser dependencies at the top of the script and fail fast with a helpful message if `jq`/`yq` (or alternative tools) are required but not installed
+
+## Pull request behaviour
+
+- When editing or creating a pull request ensure the PR title is a conventional commit message
+- When editing or creating a pull request use markdown lists to write a short summary of the changes inside the `SQUASH_MERGE` markers
+- Ensure the each line between the SQUASH_MERGE markers are less than 80 characters but complete sentences.
+- Ensure that a detailed summary of changes exists under a new heading `Copilot changes` that is separate to the existing `Changes` block
+- When working on a pull request based on an issue add a "Resolves #issue number" to the PR description under the Motivation heading

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -1,5 +1,0 @@
-## Review Style
-- Be specific and actionable in feedback.
-- Explain the "why" behind recommendations.
-- Always prioritize security vulnerabilities and performance issues that could impact users.
-- Never suggest changes to improve readability.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|w
 
 'failures' uses 'date' so any gnu date string is valid
   -d : the date string (default is "14 days ago")
+  -g --all-orgs : ALL organisations that you belong to. This is potentially a time-consuming
+                  and foolish move, so you have been warned.
+                  To mitigate, you can also set 'GH_MY_IGNORE_ORGS' as an additional filter
+                  (space separated), but the filter isn't that sophisticated.
 
 'notifs' can also mark them as read
   -n : the ID to mark as read (-n 7235590448)

--- a/includes/helper_functions
+++ b/includes/helper_functions
@@ -24,7 +24,7 @@ helper::gh_api() {
 }
 
 helper::compressQuery() {
-  echo "$1" | tr -s ' ' | tr -d '\n'
+  echo "$1" | tr -d '\n'
 }
 
 helper::std_output_format() {

--- a/includes/query_failures
+++ b/includes/query_failures
@@ -5,16 +5,41 @@ query_failures() {
   local since_dateonly
   local jq_filter
   local gh_repos
+  local query_all_orgs
+  local my_orgs
   since='14 days ago'
-  while getopts 'd:' flag; do
+  for arg in "$@"; do
+    shift
+    case "$arg" in
+    '--all-orgs' | '--allorgs')
+      set -- "$@" '-g'
+      ;;
+    *)
+      set -- "$@" "$arg"
+      ;;
+    esac
+  done
+  while getopts 'd:g' flag; do
     case "${flag}" in
     d) since="${OPTARG}" ;;
-    *) ;;
+    g) query_all_orgs='true' ;;
+    *) query_help ;;
     esac
   done
   since_dateonly=$(date --date="$since" '+%Y-%m-%d')
   jq_filter='.workflow_runs[] | "\(.repository.name)|\(.name)|\(.html_url)|\(.created_at | fromdateiso8601 | strflocaltime("%d %b %Y"))"'
-  gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
+
+  if [[ "$query_all_orgs" == 'true' ]]; then
+    my_orgs=$(helper::my_github_orgs)
+    gh_repos=$(
+      for org in $my_orgs; do
+        gh repo list "$org" --limit 1000 --json "nameWithOwner" -q ".[] | .nameWithOwner"
+      done
+    )
+  else
+    gh_repos=$(gh repo list --json "nameWithOwner" -q ".[] | .nameWithOwner")
+  fi
+
   {
     for gh_repo in $gh_repos; do
       failed_workflows=$(helper::gh_api "repos/$gh_repo/actions/runs?status=failure&created=>$since_dateonly")

--- a/includes/query_help
+++ b/includes/query_help
@@ -52,6 +52,10 @@ Usage: gh my [$ACTION_LIST] [options]
 
 'failures' uses 'date' so any gnu date string is valid
   -d : the date string (default is "14 days ago")
+  -g --all-orgs : ALL organisations that you belong to. This is potentially a time-consuming
+                  and foolish move, so you have been warned.
+                  To mitigate, you can also set 'GH_MY_IGNORE_ORGS' as an additional filter
+                  (space separated), but the filter isn't that sophisticated.
 
 'notifs' can also mark them as read
   -n : the ID to mark as read (-n 7235590448)


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
Make `gh my failures` work like `gh my prs` in support a -g mode (all orgs you belong to).

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add -g mode to show all orgs for failures
- push copilot-instructions into '.github'

<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

```
bsh ❯ gh my failures -g -d "3 days ago"
REPOSITORY  WORKFLOW             URL  WHEN
ui          Repository analysis  ...  06 Apr 2026
```
