### PR TITLE
feat: add alerts sub command to view dependabot alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ gh extension install quotidian-ennui/gh-my
 ```text
 bsh ❯ gh my
 
-Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|workload] [options]
+Usage: gh my [alerts|deployments|failures|help|issues|notifs|prs|report|reviews|vulns|workload] [options]
+  alerts      : show open dependabot alerts in the current repository
   issues      : list issues in your personal repositories
   prs         : list PRs in the current repository or all your personal repos
   reviews     : list PRs where you've been asked for a review
@@ -88,6 +89,9 @@ Usage: gh my [deployments|failures|help|issues|notifs|prs|report|reviews|vulns|w
 'notifs' can also mark them as read
   -n : the ID to mark as read (-n 7235590448)
   -a : Mark all notifications as read
+
+'alerts' shows open dependabot alerts in the current repo
+       This sub-command requires repository context.
 
 'vulns' shows vulnerabilties in your current repo by default
   -a : vulnerabilities in all your personal repositories

--- a/includes/query_alerts
+++ b/includes/query_alerts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+ALERTS_JSON_REST_JQ='
+  (["ID", "STATE", "SEVERITY", "PACKAGE", "CVE", "GHSA", "URL"]),
+  (
+    .[] | select(.state == "open") |
+    [
+      (.number | tostring),
+      (.state // ""),
+      (.security_advisory.severity // ""),
+      (.dependency.package.name // ""),
+      (.security_advisory.cve_id // ""),
+      (.security_advisory.ghsa_id // ""),
+      "https://github.com/\($repo_info)/security/dependabot/\(.number)"
+    ]
+  ) |
+  @tsv
+'
+
+query_alerts() {
+  local repo_info=""
+
+  if ! helper::is_repo; then
+    echo "alerts requires the current directory to be a github repo"
+    exit 1
+  fi
+
+  repo_info=$(helper::repo_info)
+
+  helper::gh_api "repos/:owner/:repo/dependabot/alerts" | jq -r --arg repo_info "$repo_info" "$ALERTS_JSON_REST_JQ" | column -t -s $'\t'
+}

--- a/includes/query_alerts
+++ b/includes/query_alerts
@@ -3,9 +3,7 @@ set -eo pipefail
 
 #shellcheck disable=SC2016
 ALERTS_JSON_REST_JQ='
-  (["ID", "STATE", "SEVERITY", "PACKAGE", "CVE", "GHSA", "URL"]),
-  (
-    .[] | select(.state == "open") |
+  .[] | select(.state == "open") |
     [
       (.number | tostring),
       (.state // ""),
@@ -15,8 +13,7 @@ ALERTS_JSON_REST_JQ='
       (.security_advisory.ghsa_id // ""),
       "https://github.com/\($repo_info)/security/dependabot/\(.number)"
     ]
-  ) |
-  @tsv
+  | @tsv
 '
 
 query_alerts() {
@@ -29,5 +26,7 @@ query_alerts() {
 
   repo_info=$(helper::repo_info)
 
-  helper::gh_api "repos/:owner/:repo/dependabot/alerts" | jq -r --arg repo_info "$repo_info" "$ALERTS_JSON_REST_JQ" | column -t -s $'\t'
+  helper::gh_api "repos/:owner/:repo/dependabot/alerts" \
+    | jq -r --arg repo_info "$repo_info" "$ALERTS_JSON_REST_JQ" \
+    | column -t -s $'\t' -N  "ID,STATE,SEVERITY,PACKAGE,CVE,GHSA,URL" --table-truncate URL
 }

--- a/includes/query_alerts
+++ b/includes/query_alerts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+#shellcheck disable=SC2016
 ALERTS_JSON_REST_JQ='
   (["ID", "STATE", "SEVERITY", "PACKAGE", "CVE", "GHSA", "URL"]),
   (

--- a/includes/query_help
+++ b/includes/query_help
@@ -4,6 +4,7 @@ query_help() {
   cat <<EOF
 
 Usage: gh my [$ACTION_LIST] [options]
+  alerts      : show open dependabot alerts in the current repository
   issues      : list issues in your personal repositories
   prs         : list PRs in the current repository or all your personal repos
   reviews     : list PRs where you've been asked for a review
@@ -60,6 +61,9 @@ Usage: gh my [$ACTION_LIST] [options]
 'notifs' can also mark them as read
   -n : the ID to mark as read (-n 7235590448)
   -a : Mark all notifications as read
+
+'alerts' shows open dependabot alerts in the current repo
+       This sub-command requires repository context.
 
 'vulns' shows vulnerabilties in your current repo by default
   -a : vulnerabilities in all your personal repositories


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- docs: update docs
- feat: add alerts sub command


<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

```
Ubuntu-24.04 phooey .../powerwall-exporter 
bsh ❯ gh my alerts
ID  STATE  SEVERITY  PACKAGE                             CVE             GHSA                 URL
48  open   medium    io.opentelemetry:opentelemetry-api  CVE-2026-45292  GHSA-rcgg-9c38-7xpx  https://github.com/quotidian-ennui/tesla-powerwall-exporter/security/dependabot/48
```
