### PR TITLE
feat: add GH_MY_PRS_QUERY_EXTRAS env-var for filtering purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Usage: gh my [alerts|deployments|failures|help|issues|notifs|prs|report|reviews|
   -u            : reduce the output so that the URL is primary
                   maybe you dislike 'gh my prs -j | jq -r '.url' | xargs -r L1 gh pr view -w'
 
+Environment for 'prs':
+  'GH_MY_PRS_QUERY_EXTRAS' - this environment variable is appended to the prs query so you
+                             can do something like "-label:backlog" to filter the query.
+
 'deployments' needs more filters
   -o : the organisation (e.g. -o my-company)
   -t : the topic  (e.g. -t my-terraform-repos)

--- a/includes/query_help
+++ b/includes/query_help
@@ -39,6 +39,10 @@ Usage: gh my [$ACTION_LIST] [options]
   -u            : reduce the output so that the URL is primary
                   maybe you dislike 'gh my prs -j | jq -r '.url' | xargs -r L1 gh pr view -w'
 
+ Environment for 'prs':
+  'GH_MY_PRS_QUERY_EXTRAS' - this environment variable is appended to the prs query so you
+                             can do something like "-label:backlog" to filter the query.
+
 'deployments' needs more filters
   -o : the organisation (e.g. -o my-company)
   -t : the topic  (e.g. -t my-terraform-repos)

--- a/includes/query_prs
+++ b/includes/query_prs
@@ -110,14 +110,21 @@ QUERY_JQ_FILTER='.data.search.edges[] | .node | { "number":.number, "title": .ti
 
 _prs_repo_query() {
   local gitRemote=""
+  local queryExtras="${GH_MY_PRS_QUERY_EXTRAS:-}"
   if helper::is_repo; then
     gitRemote=$(helper::repo_info)
   fi
   if [[ -n "$gitRemote" ]]; then
-    echo "is:open is:pr repo:$gitRemote archived:false"
+    echo "is:open is:pr repo:$gitRemote archived:false $queryExtras"
   else
-    echo "$PR_ALL_REPOS_QUERY"
+    echo "$PR_ALL_REPOS_QUERY $queryExtras"
   fi
+}
+
+_prs_org_query() {
+  local org="$1"
+  local queryExtras="${GH_MY_PRS_QUERY_EXTRAS:-}"
+  echo "${PR_ORG_REPOS_QUERY//"__MYORG__"/"${org}"} $queryExtras"
 }
 
 _prs_do_query() {
@@ -198,7 +205,7 @@ query_prs() {
   if [[ "$queryAllOrgs" == "true" ]]; then
     myOrgs=$(helper::my_github_orgs)
     for org in $myOrgs; do
-      queryString="${PR_ORG_REPOS_QUERY//"__MYORG__"/"${org}"}"
+      queryString="$(_prs_org_query "$org")"
       if [[ "$outputFormat" != "json" ]]; then
         echo -e "\n🏛️ $org"
       fi


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add GH_MY_PRS_QUERY_EXTRAS env-var for filtering purposes


<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

- This PR has an enhancement label, but we don't care about enhancements, so we could do something like this in this repository:

```
Ubuntu-24.04 .../gh-my  feat/additional-filtering-for-prs-query
bsh ❯ GH_MY_PRS_QUERY_EXTRAS="-label:enhancement" gh my prs
  Num  Title  Who  URL  When

Ubuntu-24.04 .../gh-my  feat/additional-filtering-for-prs-query
bsh ❯
```
- and if you don't set it, then it does show up